### PR TITLE
Fix assertion in TestDelCommand

### DIFF
--- a/redis_test.go
+++ b/redis_test.go
@@ -63,7 +63,7 @@ func TestDelCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	i, err = c.Del("abc").Result()
-	assert.Equal(t, i, int64(1))
+	assert.Equal(t, i, int64(0))
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Redis will return 0 if there is nothing to be deleted from DEL command.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>