### PR TITLE
Fix indentation issue with redis client when there are multidimensional arrays

### DIFF
--- a/cmd_dbsize.go
+++ b/cmd_dbsize.go
@@ -1,6 +1,12 @@
 package redis
 
+import "strings"
+
 // https://redis.io/commands/dbsize/
 func DbSizeCommand(c *Client, args [][]byte) {
-	c.Conn().WriteInt(c.Db().Len())
+	// TODO: For now it only returns stub values
+	var str strings.Builder
+	str.WriteString("redis_version:255.255.255\n")
+	str.WriteString("redis_git_sha1:f36eb5a1")
+	c.Conn().WriteBulkString(str.String())
 }

--- a/cmd_info.go
+++ b/cmd_info.go
@@ -1,6 +1,12 @@
 package redis
 
+import "strings"
+
 // https://redis.io/commands/info/
 func InfoCommand(c *Client, args [][]byte) {
-	c.Conn().WriteBulkString("OK")
+	// TODO: For now it only returns stub values
+	var str strings.Builder
+	str.WriteString("redis_version:255.255.255\n")
+	str.WriteString("redis_git_sha1:f36eb5a1")
+	c.Conn().WriteBulkString(str.String())
 }

--- a/resp.go
+++ b/resp.go
@@ -6,100 +6,268 @@ import (
 	"strings"
 )
 
-func CreateRespReply(in []byte) (string, []byte) {
-	var res strings.Builder
+func StringifyRespBytes(in []byte) (string, []byte) {
+	res, leftover := convertBytesToRespType(in)
+	return stringifyRespType(res, 0), leftover
+}
 
-	if len(in) == 0 {
-		return "", []byte{}
-	} else {
-		currByte := in[0]
-		if currByte == '+' {
-			str, leftover := TakeBytesUntilClrf(in[1:])
-			in = leftover
-			res.WriteString(string(str))
-		} else if currByte == '-' {
-			str, leftover := TakeBytesUntilClrf(in[1:])
-			in = leftover
-			res.WriteString(string(str))
+type RespType interface {
+	TypeId() string
+	Value() interface{}
+	RequiredWidth() int
+}
+
+type RespString struct {
+	inner []byte
+}
+
+func (rs *RespString) TypeId() string {
+	return "string"
+}
+
+func (rs *RespString) Value() interface{} {
+	return string(rs.inner)
+}
+
+func (rs *RespString) RequiredWidth() int {
+	return 0
+}
+
+type RespInteger struct {
+	inner int
+}
+
+func (rs *RespInteger) TypeId() string {
+	return "integer"
+}
+
+func (rs *RespInteger) Value() interface{} {
+	return rs.inner
+}
+
+func (rs *RespInteger) RequiredWidth() int {
+	return 0
+}
+
+type RespNil struct {
+}
+
+func (rs *RespNil) TypeId() string {
+	return "nil"
+}
+
+func (rs *RespNil) Value() interface{} {
+	return "(nil)"
+}
+
+func (rs *RespNil) RequiredWidth() int {
+	return 0
+}
+
+type RespArray struct {
+	inner []RespType
+}
+
+func (rs *RespArray) TypeId() string {
+	return "array"
+}
+
+func (rs *RespArray) Value() interface{} {
+	return rs.inner
+}
+
+// TODO: Do we actually need this?
+func (rs *RespArray) RequiredWidth() int {
+	ourWidth := 0
+	currLen := len(rs.inner)
+
+	for currLen != 0 {
+		ourWidth += 1
+		currLen /= 10
+	}
+
+	return ourWidth
+}
+
+func stringifyRespType(res RespType, width int) string {
+	if res == nil {
+		return ""
+	} else if res.TypeId() == "string" {
+		return fmt.Sprintf("\"%s\"", res.Value().(string))
+	} else if res.TypeId() == "integer" {
+		return fmt.Sprintf("(integer) %d", res.Value().(int))
+	} else if res.TypeId() == "nil" {
+		return res.Value().(string)
+	} else if res.TypeId() == "array" {
+		var str strings.Builder
+		arr := res.Value().([]RespType)
+
+		if width > 0 {
+			width += 2
+		}
+
+		var padding strings.Builder
+		for i := 0; i < width; i++ {
+			padding.WriteByte(' ')
+		}
+
+		if len(arr) == 0 {
+			return "(empty)"
+		} else {
+			for i, v := range arr {
+				if i == 0 {
+					str.WriteString(fmt.Sprintf("%d) %s\n", i+1, stringifyRespType(v, res.RequiredWidth()+width)))
+				} else if i == len(arr)-1 {
+					str.WriteString(fmt.Sprintf("%s%d) %s", padding.String(), i+1, stringifyRespType(v, res.RequiredWidth()+width)))
+				} else {
+					str.WriteString(fmt.Sprintf("%s%d) %s\n", padding.String(), i+1, stringifyRespType(v, res.RequiredWidth()+width)))
+				}
+			}
+			return str.String()
+		}
+	}
+
+	return ""
+}
+
+func convertBytesToRespType(input []byte) (RespType, []byte) {
+	// We need at least 1 byte for the first redis type byte
+	if len(input) > 0 {
+		currByte := input[0]
+		if currByte == '+' || currByte == '-' {
+			str, leftover, ok := TakeBytesUntilClrf(input[1:])
+
+			if !ok {
+				return nil, input
+			}
+
+			rs := RespString{
+				inner: str,
+			}
+
+			return &rs, leftover
 		} else if currByte == ':' {
-			str, leftover := TakeBytesUntilClrf(in[1:])
-			in = leftover
-			strInt64, err := strconv.ParseInt(string(str), 10, 32)
+			str, leftover, ok := TakeBytesUntilClrf(input[1:])
 
-			if err != nil {
-				return "", []byte{}
+			if !ok {
+				return nil, input
 			}
 
-			res.WriteString(fmt.Sprint(int(strInt64)))
+			valInt64, err := strconv.ParseInt(string(str), 10, 32)
+
+			if err != nil {
+				return nil, input
+			}
+
+			rs := RespInteger{
+				inner: int(valInt64),
+			}
+
+			return &rs, leftover
+
 		} else if currByte == '$' {
-			lenStr, leftover := TakeBytesUntilClrf(in[1:])
-			in = leftover
+			lenStr, leftover, ok := TakeBytesUntilClrf(input[1:])
+
+			if !ok {
+				return nil, input
+			}
 
 			lenInt64, err := strconv.ParseInt(string(lenStr), 10, 32)
 
 			if err != nil {
-				return "", []byte{}
+				return nil, input
 			}
 
 			if lenInt64 < 0 {
-				res.WriteString("(nil)")
+				rs := RespNil{}
+
+				return &rs, leftover
 			} else {
-				// TODO: Reuse lenInt for optimization purposes?
-				bulkStr, leftover := TakeBytesUntilClrf(in)
-				in = leftover
+				if int(lenInt64)+2 > len(leftover) {
+					return nil, input
+				} else {
+					if leftover[lenInt64] == '\r' && leftover[lenInt64+1] == '\n' {
 
-				res.WriteString(string(bulkStr))
-			}
-		} else if currByte == '*' {
-			lenStr, leftover := TakeBytesUntilClrf(in[1:])
-			in = leftover
+						rs := RespString{
+							inner: leftover[:lenInt64],
+						}
 
-			lenInt64, err := strconv.ParseInt(string(lenStr), 10, 32)
-
-			if err != nil {
-				return "", []byte{}
-			}
-
-			if lenInt64 < 0 {
-				return "", []byte{}
-			} else if lenInt64 == 0 {
-				res.WriteString("(empty)")
-			} else {
-				for idx := 0; idx < int(lenInt64) && len(in) != 0; idx++ {
-					reply, leftover := CreateRespReply(in)
-					in = leftover
-					res.WriteString(fmt.Sprintf("%d) \"%s\"", idx+1, EscapeString(reply)))
-					if idx+1 < int(lenInt64) && len(in) != 0 {
-						res.WriteByte('\n')
+						return &rs, leftover[lenInt64+2:]
+					} else {
+						return nil, input
 					}
 				}
+			}
+		} else if currByte == '*' {
+			lenStr, leftover, ok := TakeBytesUntilClrf(input[1:])
+
+			if !ok {
+				return nil, input
+			}
+
+			lenInt64, err := strconv.ParseInt(string(lenStr), 10, 32)
+
+			if err != nil {
+				return nil, input
+			}
+
+			// We parsed the length of the array, now we march forward
+			nextInput := leftover
+
+			if lenInt64 < 0 {
+				return nil, input
+			} else if lenInt64 == 0 {
+				rs := RespArray{
+					inner: make([]RespType, 0),
+				}
+
+				return &rs, leftover
+			} else {
+				replies := make([]RespType, 0, lenInt64)
+				for idx := 0; idx < int(lenInt64) && len(nextInput) != 0; idx++ {
+					reply, leftover := convertBytesToRespType(nextInput)
+
+					// If any of the elements are bad or we can't make progress, just bail
+					if reply == nil || len(leftover) == len(nextInput) {
+						return nil, input
+					}
+
+					nextInput = leftover
+					replies = append(replies, reply)
+				}
+
+				if len(replies) != int(lenInt64) {
+					return nil, input
+				}
+
+				rs := RespArray{
+					inner: replies,
+				}
+
+				return &rs, nextInput
 			}
 		}
 	}
 
-	return res.String(), in
+	return nil, input
 }
 
-func ParseRespString(in []byte) (string, []byte, bool) {
-	str, leftover := TakeBytesUntilClrf(in)
-	return string(str), leftover, true
-}
-
-func TakeBytesUntilClrf(in []byte) ([]byte, []byte) {
-
-	// If there's not even enough space for \r\n,
-	// its a bad input and we return empty
-	if len(in) < 2 {
-		return []byte{}, []byte{}
+func TakeBytesUntilClrf(in []byte) ([]byte, []byte, bool) {
+	if len(in) == 0 {
+		return []byte{}, []byte{}, false
 	}
 
-	res := []byte{}
-
-	for idx := 0; idx+2 < len(in) && in[idx] != '\r' && in[idx+1] != '\n'; idx++ {
-		res = append(res, in[idx])
+	idx := 0
+	// We don't have to check for escapes here because we check for both CRLF
+	for len(in) > idx+1 && !(in[idx] == '\r' && in[idx+1] == '\n') {
+		idx++
 	}
 
-	return res, in[len(res)+2:]
+	if len(in) > idx+1 && in[idx] == '\r' && in[idx+1] == '\n' {
+		return in[:idx], in[idx+2:], true
+	} else {
+		return in, []byte{}, false
+	}
 }
 
 func SplitStringIntoArgs(s string) ([]string, bool) {


### PR DESCRIPTION
Also added a bunch of tests for good and bad RESP strings.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>