### PR TITLE
Fix INFO command which means we passes printver

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Or if you want to only execute a certain test, you can do,
 - [ ] Tests
   - [x] unit/types/set
   - [x] unit/types/string
+  - [x] unit/printver
 
 ### TODO beside Roadmap
 

--- a/cmd_info.go
+++ b/cmd_info.go
@@ -1,6 +1,13 @@
 package redis
 
+import "strings"
+
 // https://redis.io/commands/info/
 func InfoCommand(c *Client, args [][]byte) {
-	c.Conn().WriteBulkString("OK")
+	// TODO: These are just stub values at the moment
+	// Implementing this probably requires some modification to the build system
+	var str strings.Builder
+	str.WriteString("redis_version:255.255.255\r\n")
+	str.WriteString("redis_git_sha1:f36eb5a1\r\n")
+	c.Conn().WriteBulkString(str.String())
 }


### PR DESCRIPTION
For now it is just a stub function.
Proper implementation of this requires some kind of cross platform build system which we don't want to bother with at the moment.

One solution is to prolly bundle a Go binary that is basically a script.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>