### PR TITLE
Shorten the keyexpirer test to be in msec range

### DIFF
--- a/keyexpire_test.go
+++ b/keyexpire_test.go
@@ -10,10 +10,10 @@ import (
 func TestKeyExpirer(t *testing.T) {
 	c := CreateTestClient()
 
-	s, err := c.Set("a", "v", 53*time.Millisecond).Result()
+	s, err := c.Set("a", "v", 5*time.Millisecond).Result()
 	assert.Equal(t, "OK", s)
 	assert.NoError(t, err)
-	time.Sleep(1 * time.Second)
+	time.Sleep(50 * time.Millisecond)
 
 	s, err = c.Get("a").Result()
 	assert.NotEqual(t, "v", s)


### PR DESCRIPTION
Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>