### PR TITLE
 ZSET no longer stores SortedSet internally as pointer

### DIFF
--- a/cmd_zadd.go
+++ b/cmd_zadd.go
@@ -136,7 +136,7 @@ func ZaddCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	addedCount := 0
 	var newScore *float64 = nil

--- a/cmd_zcount.go
+++ b/cmd_zcount.go
@@ -34,7 +34,7 @@ func ZcountCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	options := DefaultRangeOptions()
 	options.startExclusive = startExclusive

--- a/cmd_zlexcount.go
+++ b/cmd_zlexcount.go
@@ -83,7 +83,7 @@ func ZlexcountCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByLex(start, stop, GetRangeOptions{
 		reverse:        false,

--- a/cmd_zmpop.go
+++ b/cmd_zmpop.go
@@ -127,7 +127,7 @@ func ZmpopCommand(c *Client, args [][]byte) {
 			return
 		}
 
-		set := maybeSet.Value().(SortedSet)
+		set := maybeSet.Value().(*SortedSet)
 
 		if count > set.Len() {
 			count = set.Len()

--- a/cmd_zpopmax.go
+++ b/cmd_zpopmax.go
@@ -53,7 +53,7 @@ func ZpopmaxCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	if count > set.Len() {
 		count = set.Len()

--- a/cmd_zpopmin.go
+++ b/cmd_zpopmin.go
@@ -53,7 +53,7 @@ func ZpopminCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	if count > set.Len() {
 		count = set.Len()

--- a/cmd_zrange.go
+++ b/cmd_zrange.go
@@ -104,7 +104,7 @@ func ZrangeCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	var res []*SortedSetNode
 

--- a/cmd_zrangebylex.go
+++ b/cmd_zrangebylex.go
@@ -83,7 +83,7 @@ func ZrangebylexCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByLex(start, stop, GetRangeOptions{
 		reverse:        false,

--- a/cmd_zrangebyscore.go
+++ b/cmd_zrangebyscore.go
@@ -87,7 +87,7 @@ func ZrangebyscoreCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByScore(start, stop, GetRangeOptions{
 		reverse:        false,

--- a/cmd_zremrangebylex.go
+++ b/cmd_zremrangebylex.go
@@ -36,7 +36,7 @@ func ZremrangebylexCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByLex(start, stop, GetRangeOptions{
 		reverse:        false,

--- a/cmd_zremrangebyrank.go
+++ b/cmd_zremrangebyrank.go
@@ -36,7 +36,7 @@ func ZremrangebyrankCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByIndex(start, stop, GetRangeOptions{
 		reverse:        false,

--- a/cmd_zremrangebyscore.go
+++ b/cmd_zremrangebyscore.go
@@ -36,7 +36,7 @@ func ZremrangebyscoreCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByScore(start, stop, GetRangeOptions{
 		reverse:        false,

--- a/cmd_zrevrange.go
+++ b/cmd_zrevrange.go
@@ -53,7 +53,7 @@ func ZrevrangeCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	options := DefaultRangeOptions()
 	options.reverse = true

--- a/cmd_zrevrangebylex.go
+++ b/cmd_zrevrangebylex.go
@@ -82,7 +82,7 @@ func ZrevrangebylexCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByLex(start, stop, GetRangeOptions{
 		reverse:        true,

--- a/cmd_zrevrangebyscore.go
+++ b/cmd_zrevrangebyscore.go
@@ -87,7 +87,7 @@ func ZrevrangebyscoreCommand(c *Client, args [][]byte) {
 		return
 	}
 
-	set := maybeSet.Value().(SortedSet)
+	set := maybeSet.Value().(*SortedSet)
 
 	res := set.GetRangeByScore(start, stop, GetRangeOptions{
 		reverse:        true,

--- a/t_zset.go
+++ b/t_zset.go
@@ -12,14 +12,14 @@ type SerdeZSet struct {
 }
 
 type ZSet struct {
-	inner SortedSet
+	inner *SortedSet
 }
 
 func NewZSet() *ZSet {
-	return &ZSet{inner: *NewSortedSet()}
+	return &ZSet{inner: NewSortedSet()}
 }
 
-func NewZSetFromSs(value SortedSet) *ZSet {
+func NewZSetFromSs(value *SortedSet) *ZSet {
 	return &ZSet{inner: value}
 }
 


### PR DESCRIPTION
1. Stores `SortedSet` as pointers. This should remove some copying.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>